### PR TITLE
增加自定义路径支持

### DIFF
--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -8,6 +8,7 @@ export default {
 	'Enter your secret key': 'Enter your secret key',
 	'Enter your region': 'Enter your region',
 	'Enter your bucket': 'Enter your bucket',
+	'Enter your custom path': 'Enter your custom path, support variable {year} {month} {day}',
 	'Enter your port': 'Enter your port',
 
 	'Object rules': 'Object rules',

--- a/src/locale/zh-cn.ts
+++ b/src/locale/zh-cn.ts
@@ -8,6 +8,7 @@ export default {
 	'Enter your secret key': '请输入 Secret Key',
 	'Enter your region': '输入存储地区',
 	'Enter your bucket': '输入存储桶',
+	'Enter your custom path': '输入自定义路径，支持变量{year} {month} {day}',
 	'Enter your port': '端口号',
 
 	'Object rules': '对象规则',

--- a/src/locale/zh-tw.ts
+++ b/src/locale/zh-tw.ts
@@ -8,6 +8,7 @@ export default {
 	'Enter your secret key': 'Secret Key',
 	'Enter your region': '存儲地區',
 	'Enter your bucket': '存储桶',
+	'Enter your custom path': '輸入自訂路徑，支援變量{year} {month} {day}',
 	'Enter your port': '端口號',
 
 	'Object rules': '對象規則',


### PR DESCRIPTION
1、增加自定义路径支持，并支持在自定义路径中使用{year} {month} {day}变量，例如media/{year}/{month}表示在media路径下按当前年份和月份增加2级路径；
2、解决文件名存在空格时无法预览的问题。